### PR TITLE
Update create-alias.rst

### DIFF
--- a/awscli/examples/kms/create-alias.rst
+++ b/awscli/examples/kms/create-alias.rst
@@ -3,7 +3,7 @@ Example: Create an CMK alias
 
 The following command creates the ``example-alias`` alias. It associates the alias with the customer master key (CMK) that has CMK ID ``1234abcd-12ab-34cd-56ef-1234567890ab``.
 
-Alias names must begin with ``alias/``. Do not use alias names that begin with ``alias/aws``; they are reserved for use by AWS. To associate the alias with a different CMK, use the `Decrypt <decrypt.html>_` `UpdateAlias <update-alias.html>`_ operation.
+Alias names must begin with ``alias/``. Do not use alias names that begin with ``aws``; they are reserved for use by AWS. To associate the alias with a different CMK, use the `UpdateAlias <update-alias.html>`_ operation.
 
 .. code::
 

--- a/awscli/examples/kms/create-alias.rst
+++ b/awscli/examples/kms/create-alias.rst
@@ -3,8 +3,8 @@ Example: Create an CMK alias
 
 The following command creates the ``example-alias`` alias. It associates the alias with the customer master key (CMK) that has CMK ID ``1234abcd-12ab-34cd-56ef-1234567890ab``.
 
-Alias names must begin with ``alias/``. Do not use alias names that begin with ``aws``; they are reserved for use by AWS. To associate the alias with a different CMK, use the `UpdateAlias <update-alias.html>`_ operation.
+When specifying an alias, type ``alias/`` before the alias name. For example, ``alias/myAlias``. Alias names cannot begin with ``aws``; that name is reserved for AWS aliases. To associate the alias with a different CMK, use the `UpdateAlias <update-alias.html>`_ operation.
 
 .. code::
 
-    aws kms create-alias --alias-name alias/example-alias --target-key-id 1234abcd-12ab-34cd-56ef-1234567890ab
+    aws kms create-alias --alias-name alias/exampleAlias --target-key-id 1234abcd-12ab-34cd-56ef-1234567890ab


### PR DESCRIPTION
Modified explanation text.

Removed 'alias/' from sentence beginning "Alias names must begin with..." to line up with wording in our documentation [1].

Removed the reference to the Decrypt API operation as this is not related to modifying an alias [2].

[1] https://docs.aws.amazon.com/awscloudtrail/latest/userguide/KMS-key-naming-requirements.html
[2] https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html