### PR TITLE
Update encrypt.rst

### DIFF
--- a/awscli/examples/kms/encrypt.rst
+++ b/awscli/examples/kms/encrypt.rst
@@ -99,7 +99,7 @@ The encryption context can include multiple name-value pairs separated by a comm
 * File containing JSON or shorthand syntax
 .. code::
 
-    aws kms encrypt --encryption-context file://encryptionContext --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext "hello world" --output text --query CiphertextBlob | base64 --decode > ExampleEncryptedMessage
+    aws kms encrypt --encryption-context file://encryptionContext --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext 'hello world' --output text --query CiphertextBlob | base64 --decode > ExampleEncryptedMessage
     
 If you use the JSON format in a Windows command prompt (``cmd.exe``), be sure to use a backslash character (\\) to escape all quotation marks inside the curly braces. For example: 
 .. code::

--- a/awscli/examples/kms/encrypt.rst
+++ b/awscli/examples/kms/encrypt.rst
@@ -99,10 +99,10 @@ The encryption context can include multiple name-value pairs separated by a comm
 * File containing JSON or shorthand syntax
 .. code::
 
-    aws kms encrypt --encryption-context file://encryptionContext --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext 'hello world' --output text --query CiphertextBlob | base64 --decode > ExampleEncryptedMessage
+    aws kms encrypt --encryption-context file://encryptionContext --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext "hello world" --output text --query CiphertextBlob | base64 --decode > ExampleEncryptedMessage
     
 If you use the JSON format in a Windows command prompt (``cmd.exe``), be sure to use a backslash character (\\) to escape all quotation marks inside the curly braces. For example: 
 .. code::
 
-    aws kms encrypt --encryption-context '{\"Dept\": \"IT\",\"Purpose\": \"Test\"}' --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext 'hello world' --output text --query CiphertextBlob > C:\Temp\ExampleEncryptedMessage.txt
+    aws kms encrypt --encryption-context "{\"Dept\": \"IT\",\"Purpose\": \"Test\"}" --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext "hello world" --output text --query CiphertextBlob > C:\Temp\ExampleEncryptedMessage.txt
     


### PR DESCRIPTION
Set windows examples to use double quotation marks enclosing any text in the command syntax (such as the plaintext value or encryption context passed inline). Single quotes won't work. Confirming *nix examples work fine.

Please retest Windows examples to validate my changes.